### PR TITLE
Add aurora port lock logic to SDM120C to share the same 485 adapter with aurora inverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ To compile
   make clean && make
 
 <PRE>
-Usage: ./sdm120c [-a address] [-d] [-p] [-v] [-c] [-e] [-i] [-t] [-f] [-g] [-T] [[-m]|[-q]] [-b baud_rate] [-P parity] [-S bit] [-z num_retries] [-j seconds] [-w seconds] [-1 | -2] device
-       ./sdm120c [-a address] [-d] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] -s new_address device
-       ./sdm120c [-a address] [-d] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] -r baud_rate device 
-       ./sdm120c [-a address] [-d] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] -R new_time device
+Usage: ./sdm120c [-a address] [-d] [-x] [-p] [-v] [-c] [-e] [-i] [-t] [-f] [-g] [-T] [[-m]|[-q]] [-b baud_rate] [-P parity] [-S bit] [-z num_retries] [-j seconds] [-w seconds] [-1 | -2] device
+       ./sdm120c [-a address] [-d] [-x] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] [-z num_retries] [-j seconds] [-w seconds] -s new_address device
+       ./sdm120c [-a address] [-d] [-x] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] [-z num_retries] [-j seconds] [-w seconds] -r baud_rate device
+       ./sdm120c [-a address] [-d] [-x] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] [-z num_retries] [-j seconds] [-w seconds] -R new_time device
 
 where
-    -a address 	Meter number (between 1 and 247). Default: 1
-    -s new_address 	Set new meter number (between 1 and 247)
+    -a address 	   Meter number (between 1 and 247). Default: 1
+    -s new_address Set new meter number (between 1 and 247)
     -p             Get power (W)
     -v             Get voltage (V)
     -c             Get current (A)
@@ -36,6 +36,7 @@ where
     -t             Get total energy (Wh)
     -T             Get Time for rotating display values (0 = no rotation) 
     -d             Debug
+    -x             Trace (libmodbus debug on)
     -b baud_rate   Use baud_rate serial port speed (1200, 2400, 4800, 9600)
                    Default: 2400
     -P parity      Use parity (E, N, O)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To compile
   make clean && make
 
 <PRE>
-Usage: ./sdm120c [-a address] [-d] [-p] [-v] [-c] [-e] [-i] [-t] [-f] [-g] [-T] [[-m]|[-q]] [-b baud_rate] [-P parity] [-S bit] [-z num_retries] [-j seconds] [-1 | -2] device
+Usage: ./sdm120c [-a address] [-d] [-p] [-v] [-c] [-e] [-i] [-t] [-f] [-g] [-T] [[-m]|[-q]] [-b baud_rate] [-P parity] [-S bit] [-z num_retries] [-j seconds] [-w seconds] [-1 | -2] device
        ./sdm120c [-a address] [-d] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] -s new_address device
        ./sdm120c [-a address] [-d] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] -r baud_rate device 
        ./sdm120c [-a address] [-d] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] -R new_time device
@@ -47,6 +47,7 @@ where
     -z num_retries Try to read max num_retries times on bus before exiting
                    with error. Default: 1
     -j seconds     Response timeout. Default: 2
+    -w seconds	   tTime to wait to lock serial port. (1-30) Default: 0
     -1             Model: SDM120C (defualt)
     -2             Model: SDM220
     device         Serial device, i.e. /dev/ttyUSB0

--- a/aurora/aurora.diff
+++ b/aurora/aurora.diff
@@ -1,0 +1,26 @@
+--- /root/aurora-1.8.8/main.c	2015-01-27 02:37:17.397517079 +0100
++++ /root/my-aurora-1.8.8/main.c	2015-08-18 14:07:38.885727145 +0200
+@@ -414,18 +414,18 @@
+             if (rPID == PID) fprintf (stderr, " = me");
+             fprintf (stderr, "\n");
+         }
+-        if (command != NULL) {
+-            free(command);
+-            command = NULL;
+-        }
+         if (rPID != PID) {
+-             if (SubStrPos == NULL) {
++             if (command == NULL) {	// Clear stale only rPID process is dead 
+                  if (bVerbose) fprintf (stderr, "\n");
+                  fprintf(stderr, "%s: %s: Clearing stale serial port lock. (%lu)\n",getCurTime(),ProgramName,rPID);
+                  ClrSerLock(rPID);
+              } else if (yLockWait > 0)
+                  sleep(1);
+         }
++        if (command != NULL) {
++            free(command);
++            command = NULL;
++        }
+     }
+     if (bVerbose && rPID == PID) fprintf(stderr, "Appears we got the lock.\n");
+     if (rPID != PID) {

--- a/metern/comapps/README.md
+++ b/metern/comapps/README.md
@@ -7,7 +7,7 @@ There are 2 blocks of files:
 First ones are the first version, the latter is the last version.
 
 To use pooler485.sh, create a symbolic link
-<PRE>ln -s /var/www/metern/comapps /usr/local/bin/pooler485 
+<PRE>ln -s /var/www/metern/comapps/pooler485.sh /usr/local/bin/pooler485 
 </PRE>
 then add in /etc/rc.local
 <PRE>

--- a/sdm120c.c
+++ b/sdm120c.c
@@ -21,6 +21,8 @@ extern "C" {
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <sys/types.h>
+#include <time.h>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -78,13 +80,26 @@ extern "C" {
 #define RESTART_FALSE 0
 
 int debug_flag     = 0;
-const char *version = "1.1.5";
+const char *version = "1.1.5-TD";
+
+#define  ProgramName "sdm120c"
+
+#define	ttyLCKloc	"/var/lock/LCK.."	/* location and prefix of serial port lock file */
+
+long unsigned int PID;
+static int yLockWait = 0;	/* Seconds to wait to lock serial port */
+char *devLCKfile = NULL;
+char *devLCKfileNew = NULL;
+unsigned char yDelay;		/* Read wait time */
+int yTimeout = 0;		/* read timeout value in us */
+int yMaxRunTime = 0;		/* max seconds to run trying to get data from SC120C */
+
 
 void usage(char* program) {
     printf("sdm120c %s: ModBus RTU client to read EASTRON SDM120C smart mini power meter registers\n",version);
     printf("Copyright (C) 2015 Gianfranco Di Prinzio <gianfrdp@inwind.it>\n");
     printf("Complied with libmodbus %s\n\n", LIBMODBUS_VERSION_STRING);
-    printf("Usage: %s [-a address] [-d] [-p] [-v] [-c] [-e] [-i] [-t] [-f] [-g] [-T] [[-m]|[-q]] [-b baud_rate] [-P parity] [-S bit] [-z num_retries] [-j seconds] [-1 | -2] device\n", program);
+    printf("Usage: %s [-a address] [-d] [-p] [-v] [-c] [-e] [-i] [-t] [-f] [-g] [-T] [[-m]|[-q]] [-b baud_rate] [-P parity] [-S bit] [-z num_retries] [-j seconds] [-w seconds] [-1 | -2] device\n", program);
     printf("       %s [-a address] [-d] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] -s new_address device\n", program);
     printf("       %s [-a address] [-d] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] -r baud_rate device \n", program);
     printf("       %s [-a address] [-d] [-b baud_rate] [-P parity] [-S bit] [-1 | -2] -R new_time device\n\n", program);
@@ -112,10 +127,95 @@ void usage(char* program) {
     printf("\t-z num_retries\tTry to read max num_retries times on bus before exiting\n");
     printf("\t\t\twith error. Default: 1\n");
     printf("\t-j seconds\tResponse timeout. Default: 2\n");
-    printf("\t-1 \t\tModel: SDM120C (defualt)\n");
+    printf("\t-w seconds\tTime to wait to lock serial port. (1-30) Default: 0\n");
+    printf("\t-1 \t\tModel: SDM120C (default)\n");
     printf("\t-2 \t\tModel: SDM220\n");
     printf("\tdevice\t\tSerial device, i.e. /dev/ttyUSB0\n\n");
     printf("Serial device is required. When no parameter is passed, retrives all values\n");
+}
+
+/*--------------------------------------------------------------------------
+    getCurTime
+----------------------------------------------------------------------------*/
+char* getCurTime()
+{
+    time_t curTimeValue;
+    struct tm timStruct;
+    static char CurTime[18] = " ";
+
+    curTimeValue = time(NULL);
+    timStruct = *(localtime(&curTimeValue));
+    strftime(CurTime,sizeof(CurTime),"%Y%m%d-%H:%M:%S",&timStruct);
+    CurTime[sizeof(CurTime)-1] = '\0';
+
+    return CurTime;
+}
+
+/*--------------------------------------------------------------------------
+        getMemPtr
+----------------------------------------------------------------------------*/
+void *getMemPtr(size_t mSize)
+{
+    void *ptr;
+    char *cptr;
+    int i;
+
+    ptr = malloc(mSize);
+    if (!ptr) {
+        fprintf(stderr, "\nvproweather: malloc failed\n");
+        exit(2);
+    }
+    cptr = (char *)ptr;
+    for (i = 0; i < mSize; i++) cptr[i] = '\0';
+    return ptr;
+}
+
+/*--------------------------------------------------------------------------
+    ClrSerLock
+    Clear Serial Port lock.
+----------------------------------------------------------------------------*/
+int ClrSerLock(long unsigned int PID) {
+    FILE *fdserlck, *fdserlcknew;
+    long unsigned int rPID;
+    int bWrite, bRead;
+    int errno_save = 0;
+
+    errno = 0;
+    if (debug_flag) fprintf(stderr, "\ndevLCKfile: <%s>\ndevLCKfileNew: <%s>\nClearing Serial Port Lock (%lu)...", devLCKfile, devLCKfileNew, PID);
+    fdserlck = fopen(devLCKfile, "r");
+    if (fdserlck == NULL) {
+        if (debug_flag) fprintf(stderr, "\n");
+        fprintf(stderr, "\n%s: %s: Problem opening serial device lock file to clear PID %lu: %s for read.\n\n",getCurTime(),ProgramName,PID,devLCKfile);
+        return(0);
+    }
+    fdserlcknew = fopen(devLCKfileNew, "w");
+    if (fdserlcknew == NULL) {
+        if (debug_flag) fprintf(stderr, "\n");
+        fprintf(stderr, "\n%s: %s: Problem opening new serial device lock file to clear PID %lu: %s for write.\n\n",getCurTime(),ProgramName,PID,devLCKfileNew);
+        fclose(fdserlck);
+        return(0);
+    }
+    bRead = fscanf(fdserlck, "%lu", &rPID);
+    while (bRead != EOF) {
+        if (rPID != PID) {
+            errno = 0;
+            bWrite = fprintf(fdserlcknew, "%lu\n", rPID);
+            errno_save = errno;
+            if (bWrite < 0 || errno_save != 0) {
+                fprintf(stderr, "\n%s: %s: Problem clearing serial device lock, can't write lock file: %s.\n%s\n\n",getCurTime(),ProgramName,devLCKfile,strerror (errno_save));
+                fclose(fdserlcknew);
+                return(0);
+            }
+        }
+        bRead = fscanf(fdserlck, "%lu", &rPID);
+    }
+    fclose(fdserlck);
+    fclose(fdserlcknew);
+    errno = 0;
+    if (rename(devLCKfileNew,devLCKfile)) fprintf(stderr, "\n%s: %s: Problem clearing serial device lock, can't update lock file: %s.\n%s\n\n",getCurTime(),ProgramName,devLCKfile,strerror (errno));
+    if (debug_flag) fprintf(stderr, " done.\n");
+
+    return -1;
 }
 
 inline int bcd2int(int val)
@@ -159,7 +259,7 @@ int getMeasureBCD(modbus_t *ctx, int address, int retries, int nb) {
       j++;
 
       if (debug_flag == 1) {
-         printf("%d/%d. Register Address %d [%04X]\n", j, retries, 30000+address+1, address);
+         fprintf(stderr, "%d/%d. Register Address %d [%04X]\n", j, retries, 30000+address+1, address);
       }
       rc = modbus_read_input_registers(ctx, address, nb, tab_reg);
 
@@ -180,7 +280,7 @@ int getMeasureBCD(modbus_t *ctx, int address, int retries, int nb) {
 
     if (debug_flag == 1) {
        for (i=0; i < rc; i++) {
-          printf("reg[%d/%d]=%d (0x%X)\n", i, (rc-1), tab_reg[i], tab_reg[i]);
+          fprintf(stderr, "reg[%d/%d]=%d (0x%X)\n", i, (rc-1), tab_reg[i], tab_reg[i]);
        }
     }
 
@@ -196,15 +296,15 @@ float getMeasureFloat(modbus_t *ctx, int address, int retries, int nb) {
     int i;
     int j = 0;
     int exit_loop = 0;
-    
+
     while (j < retries && exit_loop == 0) {
       j++;
-      
+
       if (debug_flag == 1) {
-         printf("%d/%d. Register Address %d [%04X]\n", j, retries, 30000+address+1, address); 
+         fprintf(stderr, "%d/%d. Register Address %d [%04X]\n", j, retries, 30000+address+1, address); 
       }
       rc = modbus_read_input_registers(ctx, address, nb, tab_reg);
-      
+
       if (rc == -1) {
         fprintf(stderr, "ERROR %s, %d\n", modbus_strerror(errno), j);
         modbus_flush(ctx);
@@ -213,16 +313,16 @@ float getMeasureFloat(modbus_t *ctx, int address, int retries, int nb) {
         exit_loop = 1;
       }
     }
-    
+
     if (rc == -1) {
       modbus_close(ctx);
       modbus_free(ctx);
       exit(EXIT_FAILURE);
     }
-    
+
     if (debug_flag == 1) {
        for (i=0; i < rc; i++) {
-          printf("reg[%d/%d]=%d (0x%X)\n", i, (rc-1), tab_reg[i], tab_reg[i]);
+          fprintf(stderr, "reg[%d/%d]=%d (0x%X)\n", i, (rc-1), tab_reg[i], tab_reg[i]);
        }
     }
 
@@ -250,7 +350,7 @@ int getConfigBCD(modbus_t *ctx, int address, int retries, int nb) {
       j++;
 
       if (debug_flag == 1) {
-         printf("%d/%d. Register Address %d [%04X]\n", j, retries, 400000+address+1, address);
+         fprintf(stderr, "%d/%d. Register Address %d [%04X]\n", j, retries, 400000+address+1, address);
       }
       rc = modbus_read_registers(ctx, address, nb, tab_reg);
 
@@ -266,12 +366,13 @@ int getConfigBCD(modbus_t *ctx, int address, int retries, int nb) {
     if (rc == -1) {
       modbus_close(ctx);
       modbus_free(ctx);
+      ClrSerLock(PID);
       exit(EXIT_FAILURE);
     }
 
     if (debug_flag == 1) {
        for (i=0; i < rc; i++) {
-          printf("reg[%d/%d]=%d (0x%X)\n", i, (rc-1), tab_reg[i], tab_reg[i]);
+          fprintf(stderr, "reg[%d/%d]=%d (0x%X)\n", i, (rc-1), tab_reg[i], tab_reg[i]);
        }
     }
 
@@ -300,6 +401,7 @@ void changeConfigFloat(modbus_t *ctx, int address, int new_value, int restart, i
         printf("errno: %s, %d, %d\n", modbus_strerror(errno), errno, n);
         modbus_close(ctx);
         modbus_free(ctx);
+	ClrSerLock(PID);
         exit(EXIT_FAILURE);
     }
 }
@@ -318,6 +420,7 @@ void changeConfigBCD(modbus_t *ctx, int address, int new_value, int restart, int
         printf("errno: %s, %d, %d\n", modbus_strerror(errno), errno, n);
         modbus_close(ctx);
         modbus_free(ctx);
+	ClrSerLock(PID);
         exit(EXIT_FAILURE);
     }
 }
@@ -355,7 +458,7 @@ int main(int argc, char* argv[])
 #endif
     int index;
     int c;
-    char *device       = NULL;
+    char *szttyDevice  = NULL;
     char *c_parity     = NULL;
     int speed          = 0;
     int bits           = 0;
@@ -366,6 +469,17 @@ int main(int argc, char* argv[])
     const char *ODD_parity  = "O";
     char parity             = E_PARITY;
 
+    char *pos;
+    FILE *fdserlck = NULL;
+    long unsigned int rPID;
+    char sPID[10];
+    int bRead, bWrite, lckCNT;
+    int errno_save = 0;
+    int fLen = 0;
+    char *cmdFile = NULL;
+    char *command = NULL;
+    char *SubStrPos = NULL;
+
     if (argc == 1) {
         usage(argv[0]);
         exit(EXIT_FAILURE);
@@ -373,7 +487,7 @@ int main(int argc, char* argv[])
 
     opterr = 0;
 
-    while ((c = getopt (argc, argv, "a:b:cdefgij:lmnpP:qr:R:s:S:tTvz:12")) != -1) {
+    while ((c = getopt (argc, argv, "a:b:cdefgij:lmnpP:qr:R:s:S:tTvw:z:12")) != -1) {
         switch (c)
         {
             case 'a':
@@ -515,6 +629,13 @@ int main(int argc, char* argv[])
             case 'j':
                 resp_timeout = atoi(optarg);
                 break;
+	    case 'w':
+		yLockWait = atoi(optarg);
+                if (yLockWait < 1 || yLockWait > 30) {
+                    fprintf(stderr, "\n%s: %s: -w Lock Wait seconds (%d) out of range, 1-30.\n",getCurTime(),ProgramName,yLockWait);
+                    return 0;
+                }
+		break;
             case 'T':
                 time_disp_flag = 1;
                 count_param++;
@@ -545,13 +666,52 @@ int main(int argc, char* argv[])
     if ((optind+1) > argc) {
         /* need at least one argument (change +1 to +2 for two, etc. as needeed) */
         if (debug_flag == 1) {
-           printf("optind = %d, argc = %d\n", optind, argc);
+           fprintf(stderr, "optind = %d, argc = %d\n", optind, argc);
         }
         usage(argv[0]);
         exit(EXIT_FAILURE);
     } else {
-        device = argv[optind];
+        szttyDevice = argv[optind];
     }
+
+
+
+    PID = getpid();
+
+    if (optind < argc) { 			/* get serial device name */
+        szttyDevice = getMemPtr(strlen(argv[optind])+1);
+        strcpy(szttyDevice, argv[optind]);
+        szttyDevice[strlen(szttyDevice)] = '\0';
+     } else {
+        fprintf(stderr, "\n%s: %s: No serial device specified\n",getCurTime(),ProgramName);
+        return 0;
+    }
+    pos = strrchr(szttyDevice, '/');
+    if (pos > 0) {
+        pos++;
+        devLCKfile = getMemPtr(strlen(ttyLCKloc)+(strlen(szttyDevice)-(pos-szttyDevice))+1);
+        devLCKfile[0] = '\0';
+        strcpy(devLCKfile,ttyLCKloc);
+        strcat(devLCKfile, pos);
+        devLCKfile[strlen(devLCKfile)] = '\0';
+        sprintf(sPID,"%lu",PID);
+        devLCKfileNew = getMemPtr(strlen(devLCKfile)+strlen(sPID)+2);	/* dot & terminator */
+        devLCKfileNew[0] = '\0';
+        strcpy(devLCKfileNew,devLCKfile);
+        sprintf(devLCKfileNew,"%s.%lu",devLCKfile,PID);
+        devLCKfileNew[strlen(devLCKfileNew)] = '\0';
+    } else {
+        devLCKfile = NULL;
+    }
+    if (debug_flag) {
+        fprintf(stderr, "\nszttyDevice: %s\nyDelay:     %i\nyTimeout    %i mS\nyMaxRunTime ",szttyDevice,yDelay,yTimeout);
+        yMaxRunTime ? fprintf(stderr, "%i S",yMaxRunTime) : fprintf(stderr, "~");
+        fprintf(stderr, "\ndevLCKfile: <%s>\ndevLCKfileNew: <%s>\n",devLCKfile,devLCKfileNew);
+    }
+
+
+
+
 
     if (compact_flag == 1 && metern_flag == 1) {
         fprintf(stderr, "Parameter -m and -q are mutually exclusive\n\n");
@@ -559,13 +719,105 @@ int main(int argc, char* argv[])
         exit(EXIT_FAILURE);
     }
 
+    if (debug_flag) fprintf(stderr, "\nAttempting to get lock on Serial Port %s...\n",szttyDevice);
+    fdserlck = fopen((const char *)devLCKfile, "a");
+    if (fdserlck == NULL) {
+        if (debug_flag) fprintf(stderr, "\n");
+        fprintf(stderr, "%s: %s: Problem locking serial device, can't open lock file: %s for write.\n\n",getCurTime(),ProgramName,devLCKfile);
+        exit(2);
+    }
+    bWrite = fprintf(fdserlck, "%lu\n", PID);
+    errno_save = errno;
+    fclose(fdserlck);
+    fdserlck = NULL;
+    if (bWrite < 0 || errno_save != 0) {
+        if (debug_flag) fprintf(stderr, "\n");
+        fprintf(stderr, "%s: %s: Problem locking serial device, can't write lock file: %s.\n%s\n\n",getCurTime(),ProgramName,devLCKfile,strerror (errno_save));
+        exit(2);
+    }
+
+    rPID = 0;
+    lckCNT = -1;
+    while(rPID != PID && lckCNT++ < yLockWait) {
+        if (debug_flag && lckCNT == 0) fprintf(stderr, "Checking for lock\n");
+        SubStrPos = NULL;
+        fdserlck = fopen(devLCKfile, "r");
+        if (fdserlck == NULL) {
+            if (debug_flag) fprintf(stderr, "\n");
+            fprintf(stderr, "%s: %s: Problem locking serial device, can't open lock file: %s for read.\n\n",getCurTime(),ProgramName,devLCKfile);
+            exit(2);
+        }
+        bRead = fscanf(fdserlck, "%lu", &rPID);
+        errno_save = errno;
+        fclose(fdserlck);
+        if (debug_flag) fprintf(stderr, "\nChecking process %lu for lock\n",rPID);
+        fdserlck = NULL;
+        if (bRead == EOF || errno_save != 0) {
+            if (debug_flag) fprintf(stderr, "\n");
+            fprintf(stderr, "%s: %s: Problem locking serial device, can't read lock file: %s.\n%s\n\n",getCurTime(),ProgramName,devLCKfile,strerror (errno_save));
+            exit(2);
+        }
+
+        sPID[0] = '\0';
+        sprintf(sPID,"%lu",rPID);
+        cmdFile = getMemPtr(strlen(sPID)+14+1);
+        cmdFile[0] = '\0';
+        sprintf(cmdFile,"/proc/%lu/cmdline",rPID);
+        cmdFile[strlen(cmdFile)] = '\0';
+        fdserlck = fopen(cmdFile, "r");
+        if (fdserlck != NULL) {
+            fLen = 0;
+            while (fgetc(fdserlck) != EOF) fLen++;
+            if (fLen > 0) {
+                command = getMemPtr(fLen+1);
+                command[0] = '\0';
+                rewind(fdserlck);
+                bRead = fscanf(fdserlck, "%s", command);
+                command[strlen(command)] = '\0';
+            }
+            fclose(fdserlck);
+            fdserlck = NULL;
+            if (command != NULL) SubStrPos = strstr(command, ProgramName);
+        }
+        if (cmdFile != NULL) {
+            free(cmdFile);
+            cmdFile = NULL;
+        }
+        if (debug_flag) {
+            fprintf (stderr, "rPID: %lu SubStrPos: %s command: %s",rPID,SubStrPos,command);
+            if (rPID == PID) fprintf (stderr, " = me");
+            fprintf (stderr, "\n");
+        }
+        if (command != NULL) {
+            free(command);
+            command = NULL;
+        }
+        if (rPID != PID) {
+             if (SubStrPos == NULL) {
+                 if (debug_flag) fprintf (stderr, "\n");
+                 fprintf(stderr, "%s: %s: Clearing stale serial port lock. (%lu)\n",getCurTime(),ProgramName,rPID);
+                 ClrSerLock(rPID);
+             } else if (yLockWait > 0)
+                 sleep(1);
+        }
+    }
+    if (debug_flag && rPID == PID) fprintf(stderr, "Appears we got the lock.\n");
+    if (rPID != PID) {
+        ClrSerLock(PID);
+        if (debug_flag) fprintf (stderr, "\n");
+        fprintf(stderr, "%s: %s: Problem locking serial device %s, couldn't get the lock for %lu, locked by %lu.\n\n",getCurTime(),ProgramName,szttyDevice,PID,rPID);
+        exit(2);
+    }
+
+
     modbus_t *ctx;
     if (baud_rate == 0) baud_rate = DEFAULT_RATE;
 
-    ctx = modbus_new_rtu(device, baud_rate, parity, 8, stop_bits);
+    ctx = modbus_new_rtu(szttyDevice, baud_rate, parity, 8, stop_bits);
 
     if (ctx == NULL) {
         fprintf(stderr, "Unable to create the libmodbus context\n");
+	ClrSerLock(PID);
         exit(EXIT_FAILURE);
     }
 
@@ -575,7 +827,7 @@ int main(int argc, char* argv[])
     uint32_t old_response_to_usec;
 
     modbus_get_response_timeout(ctx, &old_response_to_sec, &old_response_to_usec);
-    
+
     // Considering to get those values from command line
     modbus_set_byte_timeout(ctx, -1, 0);
     modbus_set_response_timeout(ctx, resp_timeout, 0);
@@ -584,7 +836,7 @@ int main(int argc, char* argv[])
 
     struct timeval old_response_timeout;
     struct timeval response_timeout;
-    
+
     modbus_get_response_timeout(ctx, &old_response_timeout);
     response_timeout.tv_sec = -1;
     response_timeout.tv_usec = 0;
@@ -596,16 +848,17 @@ int main(int argc, char* argv[])
 #endif
 
     modbus_set_error_recovery(ctx, MODBUS_ERROR_RECOVERY_LINK | MODBUS_ERROR_RECOVERY_PROTOCOL);
-                      
+
     if (debug_flag == 1) {
         modbus_set_debug(ctx, 1);
     }
     int slave = 0;
     slave = modbus_set_slave(ctx, device_address);
-    
+
     if (modbus_connect(ctx) == -1) {
         fprintf(stderr, "Connection failed: %s\n", modbus_strerror(errno));
         modbus_free(ctx);
+	ClrSerLock(PID);
         exit(EXIT_FAILURE);
     }
 
@@ -622,49 +875,55 @@ int main(int argc, char* argv[])
     int   time_disp  = 0;
 
     if (new_address > 0 && new_baud_rate > 0) {
-        
+
         fprintf(stderr, "Parameter -s and -r are mutually exclusive\n\n");
         usage(argv[0]);
         modbus_close(ctx);
         modbus_free(ctx);
+	ClrSerLock(PID);
         exit(EXIT_FAILURE);
-        
+
     } else if (new_address > 0) {
-    
+
         if (count_param > 0) {
             usage(argv[0]);
             modbus_close(ctx);
             modbus_free(ctx);
+	    ClrSerLock(PID);
             exit(EXIT_FAILURE);
         } else {
             // change Address
             changeConfigFloat(ctx, DEVICE_ID, new_address, RESTART_TRUE, 2);
             modbus_close(ctx);
             modbus_free(ctx);
+	    ClrSerLock(PID);
             return 0;
         }
-        
+
     } else if (new_baud_rate > 0) {
-    
+
         if (count_param > 0) {
             usage(argv[0]);
             modbus_close(ctx);
             modbus_free(ctx);
+	    ClrSerLock(PID);
             exit(EXIT_FAILURE);
         } else {
             // change Baud Rate
             changeConfigFloat(ctx, BAUD_RATE, new_baud_rate, RESTART_TRUE, 2);
             modbus_close(ctx);
             modbus_free(ctx);
+	    ClrSerLock(PID);
             return 0;
         }
-        
+
     } else if (rotation_time_flag > 0) {
 
         if (count_param > 0) {
             usage(argv[0]);
             modbus_close(ctx);
             modbus_free(ctx);
+	    ClrSerLock(PID);
             exit(EXIT_FAILURE);
         } else {
             // change Time Rotation
@@ -675,6 +934,7 @@ int main(int argc, char* argv[])
             }
             modbus_close(ctx);
             modbus_free(ctx);
+	    ClrSerLock(PID);
             return 0;
         }
 
@@ -835,7 +1095,7 @@ int main(int argc, char* argv[])
     } else {
         printf(" NOK\n");
     }
-    
+
     /*
     if (compact_flag == 1) {
         printf("\n");
@@ -844,6 +1104,7 @@ int main(int argc, char* argv[])
 
     modbus_close(ctx);
     modbus_free(ctx);
+    ClrSerLock(PID);
 
     return 0;
 }

--- a/sdm120c.c
+++ b/sdm120c.c
@@ -245,6 +245,10 @@ int bcd2num(const uint16_t *src, int len)
     return n;
 }
 
+#if 0
+
+// unused
+
 int getMeasureBCD(modbus_t *ctx, int address, int retries, int nb) {
 
     uint16_t tab_reg[nb * sizeof(uint16_t)];
@@ -287,6 +291,8 @@ int getMeasureBCD(modbus_t *ctx, int address, int retries, int nb) {
 
     return value;
 }
+
+#endif
 
 float getMeasureFloat(modbus_t *ctx, int address, int retries, int nb) {
 
@@ -792,7 +798,7 @@ int main(int argc, char* argv[])
             fprintf (stderr, "\n");
         }
         if (rPID != PID) {
-             if (command == NULL) {	// Clear stale only if rPID process is dead (Aurora <1.8.8 needs a patch too)
+             if (command == NULL) {	// Clear stale only if rPID process is dead (Aurora <=1.8.8 needs a patch too)
                  if (debug_flag) fprintf (stderr, "\n");
                  fprintf(stderr, "%s: %s: Clearing stale serial port lock. (%lu)\n",getCurTime(),ProgramName,rPID);
                  ClrSerLock(rPID);


### PR DESCRIPTION
With this "multi-merge" patch from aurora sources I'm now able to share the same port with aurora. sdm120c gently wait for the 485 port like aurora does. -w parameter is the same as aurora one.

I'm testing it now on my setup and it's quite stable.

Hope it helps. :)