### PR TITLE
Critical lock fix (aurora too) + Apparent and Reactive values reading + some more fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,7 @@ clean:
 	rm -f *.o ${SDM}
 
 install: ${SDM}
-	cp ${SDM} /usr/local/bin
+	install -m 4711 $(SDM) /usr/local/bin
+
+uninstall:
+	rm -f /usr/local/$(SDM)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ It depends on libmodbus (http://libmodbus.org)
 To compile
   make clean && make
 
+To install
+  make install
+
+To uninstall
+  make uninstall
+
 <PRE>
 # SDM120C
 SDM120C ModBus RTU client to read EASTRON SDM120C smart mini power meter registers
@@ -14,8 +20,8 @@ It works with SDM120C and SDM220 models
 
 It depends on libmodbus (http://libmodbus.org)
 
-To compile
-  make clean && make
+To compile and install
+  make clean && make install
 
 <PRE>
 Usage: sdm120c [-a address] [-d] [-x] [-p] [-v] [-c] [-e] [-i] [-t] [-f] [-g] [-T] [[-m]|[-q]] [-b baud_rate] [-P parity] [-S bit] [-z num_retries] [-j seconds] [-w seconds] [-1 | -2] device

--- a/aurora/aurora.diff
+++ b/aurora/aurora.diff
@@ -1,6 +1,36 @@
---- aurora-1.8.8/main.c	2015-01-27 02:37:17.397517079 +0100
-+++ my-aurora-1.8.8/main.c	2015-08-18 14:07:38.885727145 +0200
-@@ -414,18 +414,18 @@
+--- aurora-1.8.8/main.c	2015-01-27 02:37:17.000000000 +0100
++++ my-aurora-1.8.8/main.c	2015-09-13 09:49:55.965051981 +0200
+@@ -352,6 +352,7 @@
+         fprintf(stderr, "%s: %s: Problem locking serial device, can't open lock file: %s for write.\n\n",getCurTime(),ProgramName,devLCKfile);
+         exit(2);
+     }
++    errno=0;
+     bWrite = fprintf(fdserlck, "%lu\n", PID);
+     errno_save = errno;
+     fclose(fdserlck);
+@@ -373,17 +374,19 @@
+             fprintf(stderr, "%s: %s: Problem locking serial device, can't open lock file: %s for read.\n\n",getCurTime(),ProgramName,devLCKfile);
+             exit(2);
+         }
++        errno=0;
+         bRead = fscanf(fdserlck, "%lu", &rPID);
+         errno_save = errno;
+         fclose(fdserlck);
+-        if (bVerbose) fprintf(stderr, "\nChecking process %lu for lock\n",rPID);
+         fdserlck = NULL;
+         if (bRead == EOF || errno_save != 0) {
+             if (bVerbose) fprintf(stderr, "\n");
+-            fprintf(stderr, "%s: %s: Problem locking serial device, can't read lock file: %s.\n%s\n\n",getCurTime(),ProgramName,devLCKfile,strerror (errno_save));
++            fprintf(stderr, "%s: %s: Problem locking serial device, can't read PID from lock file: %s.\n",getCurTime(),ProgramName,devLCKfile);
++            if (errno_save != 0) fprintf(stderr, "%s: %s: (%u) %s\n\n",getCurTime(),ProgramName,errno,strerror(errno_save));
+             exit(2);
+         }
+ 
++        if (bVerbose) fprintf(stderr, "\nChecking process %lu for lock\n",rPID);
+         sPID[0] = '\0';
+         sprintf(sPID,"%lu",rPID);
+         cmdFile = getMemPtr(strlen(sPID)+14+1);
+@@ -414,18 +417,18 @@
              if (rPID == PID) fprintf (stderr, " = me");
              fprintf (stderr, "\n");
          }
@@ -24,3 +54,12 @@
      }
      if (bVerbose && rPID == PID) fprintf(stderr, "Appears we got the lock.\n");
      if (rPID != PID) {
+@@ -547,7 +550,7 @@
+         }
+         rc = -1;
+     }
+-    bCommCheck = FALSE;
++    //bCommCheck = FALSE;
+ 
+     if (rc == 0 && bSetTime) {
+         rc = SetTime(fdser,yAddress,FALSE);

--- a/sdm120c.c
+++ b/sdm120c.c
@@ -85,7 +85,7 @@ int trace_flag     = 0;
 
 int metern_flag    = 0;
 
-const char *version     = "1.2.2";
+const char *version     = "1.2.3";
 char *programName;
 const char *ttyLCKloc   = "/var/lock/LCK.."; /* location and prefix of serial port lock file */
 
@@ -220,6 +220,7 @@ int ClrSerLock(long unsigned int PID) {
             errno_save = errno;
             if (bWrite < 0 || errno_save != 0) {
                 log_message(debug_flag, "%s: Problem clearing serial device lock, can't write lock file: %s. %s",programName,devLCKfile,strerror (errno_save));
+                log_message(debug_flag, "%s: (%u) %s",programName,devLCKfile,errno_save,strerror(errno_save));
                 fclose(fdserlcknew);
                 return(0);
             }
@@ -487,12 +488,14 @@ void lockSer(const char *szttyDevice, int debug_flag)
         log_message(1, "Check execution permission of %s, it shoud be '-rws--x--x'.");        
         exit(2);
     }
+    errno=0;
     bWrite = fprintf(fdserlck, "%lu\n", PID);
     errno_save = errno;
     fclose(fdserlck);
     fdserlck = NULL;
     if (bWrite < 0 || errno_save != 0) {
         log_message(debug_flag, "%s: Problem locking serial device, can't write lock file: %s. %s",programName,devLCKfile,strerror (errno_save));
+        log_message(debug_flag, "%s: (%u) %s",programName,devLCKfile,errno_save, strerror(errno_save));
         exit(2);
     }
 
@@ -506,6 +509,7 @@ void lockSer(const char *szttyDevice, int debug_flag)
             log_message(debug_flag, "%s: Problem locking serial device, can't open lock file: %s for read.",programName,devLCKfile);
             exit(2);
         }
+        errno=0;
         bRead = fscanf(fdserlck, "%lu", &rPID);
         errno_save = errno;
         fclose(fdserlck);
@@ -513,7 +517,7 @@ void lockSer(const char *szttyDevice, int debug_flag)
         fdserlck = NULL;
         if (bRead == EOF || errno_save != 0) {
             log_message(debug_flag, "%s: Problem locking serial device, can't read lock file: %s.",programName,devLCKfile);
-            log_message(debug_flag, "%s",strerror (errno_save));
+            log_message(debug_flag, "%s: (%u) %s",programName,errno_save,strerror(errno_save));
             exit(2);
         }
 


### PR DESCRIPTION
Apparent and Reactive values reading + some more fixes …
- Add reading for:
        - Apparent Power
        - Reactive Power
        - Phase Angle
        - Inported Reactive Energy
        - Exported Reactive Energy

- New program version updated (v1.2.2)
- Disable "NOK" for metern output
- More log messages
- Hints for common errors
- Fatal errors are now always shown
- No params now really shows all values from meter