### PR TITLE
Resolve new baud for 2400

### DIFF
--- a/sdm120c.c
+++ b/sdm120c.c
@@ -1489,7 +1489,7 @@ int main(int argc, char* argv[])
             return 0;
         }
 
-    } else if (new_baud_rate > 0) {
+    } else if (new_baud_rate >= 0) {
 
         if (count_param > 0) {
             usage(programName);


### PR DESCRIPTION
Found that if I tried to reset my baud rate to 2400 from anything else, the tool would just ignore my request.  
  
Turn out to be a minor off by one error?