### PR TITLE
Fix compilation warning in getPIDcmd() - v1.3.5.7

### DIFF
--- a/sdm120c.c
+++ b/sdm120c.c
@@ -104,7 +104,7 @@ int trace_flag     = 0;
 
 int metern_flag    = 0;
 
-const char *version     = "1.3.5.6";
+const char *version     = "1.3.5.7";
 char *programName;
 const char *ttyLCKloc   = "/var/lock/LCK.."; /* location and prefix of serial port lock file */
 
@@ -819,7 +819,7 @@ void *getPIDcmd(long unsigned int PID)
     // Get 1st string (command)
     cmdLen=strlen(buffer)+1;
     if((COMMAND = getMemPtr(cmdLen)) != NULL ) {
-        strncpy(COMMAND, buffer, cmdLen);
+        memcpy(COMMAND, buffer, cmdLen);
         COMMAND[cmdLen-1] = '\0';
     }
 


### PR DESCRIPTION
Replace strncpy() with memcpy() to resolve -Wstringop-overflow= warning. 
The compiler warning occurred because strncpy() bound depended on the source string length. Using memcpy() is more appropriate when the exact copy length is already known. 

Changes: - Line 822: Changed strncpy(COMMAND, buffer, cmdLen) to memcpy() 
- No functional changes, code behavior remains identical 
- Clean compilation with -Wall flag Technical details: The warning was triggered because GCC detected that the size parameter passed to strncpy() was calculated from strlen(buffer)+1, which is a pattern that can lead to buffer overflows in other contexts. Since we already know the exact length and manually null-terminate, memcpy() is the semantically correct choice.